### PR TITLE
palm integration (mirroring `lik.py` in `palm`)

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,9 @@
+channels:
+  - conda-forge
+dependencies:
+  - conda-forge::python=3.7.6
+  - conda-forge::biopython=1.76
+  - conda-forge::matplotlib=3.1.2
+  - conda-forge::numba=0.47.0
+  - conda-forge::numpy=1.17.5
+  - conda-forge::scipy=1.4.1

--- a/inference.py
+++ b/inference.py
@@ -90,6 +90,8 @@ def parse_args():
 	parser.add_argument('--tSkip',type=int,default=1)
 	parser.add_argument('--df',type=int,default=150)
 	parser.add_argument('--betaParam',type=float,default=1.0)
+	parser.add_argument('--lik',action='store_true',help='saves likelihood function, used by PALM. **Only compatible when a single selection coefficient is estimated.**')
+	parser.add_argument('--w',type=float,default=0.01,help='width used to estimate likelihood function (--lik)')
 	return parser.parse_args()
 
 

--- a/inference.py
+++ b/inference.py
@@ -89,7 +89,7 @@ def parse_args():
 	parser.add_argument('--sMax',type=float,default=0.1)
 	parser.add_argument('--tSkip',type=int,default=1)
 	parser.add_argument('--df',type=int,default=150)
-	parser.add_argument('--betaParam',type=float,default=0.5)
+	parser.add_argument('--betaParam',type=float,default=1.0)
 	parser.add_argument('--lik',action='store_true',help='saves likelihood function, used by PALM. **Only compatible when a single selection coefficient is estimated.**')
 	parser.add_argument('--w',type=float,default=0.01,help='width used to estimate likelihood function (--lik)')
 	return parser.parse_args()

--- a/inference.py
+++ b/inference.py
@@ -353,7 +353,7 @@ if __name__ == "__main__":
 	if args.lik:
 		print('Fitting likelihood function...')
 		print()
-		Svec = np.linspace(S[0]-args.w,min(S[0]+args.w,sMax),20)
+		Svec = np.linspace(max(S[0]-args.w,-sMax),min(S[0]+args.w,sMax),20)
 		Lvec = []
 		for s in Svec:
 			l = likelihood_wrapper(np.array([s]),timeBins,Ne,freqs,z_bins,z_logcdf,z_logsf,ancientGLs,ancientHapGLs,epochs,noCoals,currFreq,h,sMax,changePts)

--- a/inference.py
+++ b/inference.py
@@ -90,7 +90,10 @@ def parse_args():
 	parser.add_argument('--tSkip',type=int,default=1)
 	parser.add_argument('--df',type=int,default=150)
 	parser.add_argument('--betaParam',type=float,default=0.5)
+	parser.add_argument('--lik',action='store_true',help='saves likelihood function, used by PALM. **Only compatible when a single selection coefficient is estimated.**')
+	parser.add_argument('--w',type=float,default=0.01,help='width used to estimate likelihood function (--lik)')
 	return parser.parse_args()
+
 
 
 def load_normal_tables():
@@ -214,7 +217,6 @@ def likelihood_wrapper(theta,timeBins,N,freqs,z_bins,z_logcdf,z_logsf,ancGLs,anc
         return np.inf
 
     sel = Sprime[np.digitize(epochs,timeBins,right=False)-1]
-
     tShape = times.shape
     if tShape[2] == 0:
     	t = np.zeros((2,0))
@@ -308,6 +310,10 @@ if __name__ == "__main__":
 	S0 = 0.0 * np.ones(T-1)
 	opts = {'xatol':1e-4}
 
+	if args.lik and T > 2:
+		print('ERROR: Option --lik incompatible with estimating >1 selection coefficient.')
+		raise ValueError
+
 	if T == 2:
 		Simplex = np.reshape(np.array([-0.05,0.05]),(2,1))
 	elif T > 2:
@@ -323,28 +329,44 @@ if __name__ == "__main__":
 	opts['initial_simplex']=Simplex
 	    
 	#for tup in product(*[[-1,1] for i in range(3)]):
-	logL0 = likelihood_wrapper(S0,timeBins,Ne,freqs,z_bins,z_logcdf,z_logsf,ancientGLs,ancientHapGLs,epochs,noCoals,currFreq,h,sMax,changePts)
+	logL0 = -likelihood_wrapper(S0,timeBins,Ne,freqs,z_bins,z_logcdf,z_logsf,ancientGLs,ancientHapGLs,epochs,noCoals,currFreq,h,sMax,changePts)
 
 	print('Optimizing likelihood surface using Nelder-Mead...')
 	if times.shape[2] > 1:
 		print('\t(Importance sampling with M = %d Relate samples)'%(times.shape[2]))
 		print()
 	minargs = (timeBins,Ne,freqs,z_bins,z_logcdf,z_logsf,ancientGLs,ancientHapGLs,epochs,noCoals,currFreq,h,sMax,changePts)
+	
+
 	res = minimize(likelihood_wrapper,
-	         S0,
-	         args=minargs,
-	         options=opts,
-	         #bounds=bounds,
-	        method='Nelder-Mead')
+		         S0,
+		         args=minargs,
+		         options=opts,
+		         #bounds=bounds,
+		        method='Nelder-Mead')
 
 	S = res.x
 	L = res.fun
-	#Hinv = np.linalg.inv(res.hess)
-	#se = np.sqrt(np.diag(Hinv))
+	
+	if args.lik:
+		print('Fitting likelihood function...')
+		print()
+		Svec = np.linspace(S[0]-args.w,S[0]+args.w,20)
+		Lvec = []
+		for s in Svec:
+			l = likelihood_wrapper(np.array([s]),timeBins,Ne,freqs,z_bins,z_logcdf,z_logsf,ancientGLs,ancientHapGLs,epochs,noCoals,currFreq,h,sMax,changePts)
+			Lvec.append(l)
+		Lvec = np.array(Lvec)
+		S = np.array([Svec[np.argmax(-Lvec)]])
+		L = np.max(-Lvec)
+		p = np.polyfit(Svec,Lvec,deg=2)
+		if args.out != None:
+			np.save(args.out+'.quad_fit.npy',p)
+
 
 	print('#'*10)
 	print()
-	print('logLR: %.4f'%(-res.fun+logL0))
+	print('logLR: %.4f'%(L-logL0))
 	print()
 	print('MLE:')
 	print('========')
@@ -356,7 +378,7 @@ if __name__ == "__main__":
 	# infer trajectory @ MLE of selection parameter
 	print(noCoals)
 
-	post = traj_wrapper(res.x,timeBins,Ne,freqs,z_bins,z_logcdf,z_logsf,ancientGLs,ancientHapGLs,epochs,noCoals,currFreq,h,sMax,changePts)
+	post = traj_wrapper(S,timeBins,Ne,freqs,z_bins,z_logcdf,z_logsf,ancientGLs,ancientHapGLs,epochs,noCoals,currFreq,h,sMax,changePts)
 	
 	if args.out != None:
 		out(args,epochs,freqs,post)

--- a/inference.py
+++ b/inference.py
@@ -97,10 +97,12 @@ def parse_args():
 
 
 def load_normal_tables():
+    import os
+    dname = os.path.dirname(os.path.abspath(__file__))
     # read in global Phi(z) lookups
-    z_bins = np.genfromtxt('utils/z_bins.txt')
-    z_logcdf = np.genfromtxt('utils/z_logcdf.txt')
-    z_logsf = np.genfromtxt('utils/z_logsf.txt')
+    z_bins = np.genfromtxt(os.path.join(dname, 'utils/z_bins.txt'))
+    z_logcdf = np.genfromtxt(os.path.join(dname, 'utils/z_logcdf.txt'))
+    z_logsf = np.genfromtxt(os.path.join(dname, 'utils/z_logsf.txt'))
     return z_bins,z_logcdf,z_logsf
 
 def load_times(args):

--- a/inference.py
+++ b/inference.py
@@ -353,7 +353,7 @@ if __name__ == "__main__":
 	if args.lik:
 		print('Fitting likelihood function...')
 		print()
-		Svec = np.linspace(S[0]-args.w,S[0]+args.w,20)
+		Svec = np.linspace(S[0]-args.w,min(S[0]+args.w,sMax),20)
 		Lvec = []
 		for s in Svec:
 			l = likelihood_wrapper(np.array([s]),timeBins,Ne,freqs,z_bins,z_logcdf,z_logsf,ancientGLs,ancientHapGLs,epochs,noCoals,currFreq,h,sMax,changePts)

--- a/inference.py
+++ b/inference.py
@@ -359,8 +359,9 @@ if __name__ == "__main__":
 		Lvec = np.array(Lvec)
 		S = np.array([Svec[np.argmax(-Lvec)]])
 		L = np.max(-Lvec)
-		p = np.polyfit(Svec,Lvec,deg=2)
+		p = np.polyfit(Svec,-Lvec,deg=2)
 		if args.out != None:
+			print(p)
 			np.save(args.out+'.quad_fit.npy',p)
 
 

--- a/inference.py
+++ b/inference.py
@@ -361,7 +361,6 @@ if __name__ == "__main__":
 		L = np.max(-Lvec)
 		p = np.polyfit(Svec,-Lvec,deg=2)
 		if args.out != None:
-			print(p)
 			np.save(args.out+'.quad_fit.npy',p)
 
 

--- a/inference.py
+++ b/inference.py
@@ -350,7 +350,7 @@ if __name__ == "__main__":
 	print('========')
 	print('epoch\tselection')
 	for s,t,u in zip(S,timeBins[:-1],timeBins[1:]):
-		print('%d-%d\t%.5f'%(t,u,s))
+		print('%d-%d\t%.7f'%(t,u,s))
 
 
 	# infer trajectory @ MLE of selection parameter


### PR DESCRIPTION
I tested this out locally (with input examples available from the repo) and got expected results & successfully saved the output in the `.quad_fit.npy` format needed for PALM. The usage looks like:

`python inference.py --ancientSamps example/exampleAncientSamps3.txt --timeBins example/timeBins200.txt --lik --out test`

which saves a `test.quad_fit.npy` file that summarizes the likelihood surface for that particular SNP. (PALM will require you to generate `.quad_fit.npy` for each locus you want to include in your likelihood*)

You should be able to follow the instructions on the PALM wiki to format the GWAS summary statistics and (after having run `clues/inference.py --lik` as demoed above) you should be able to run `palm.py`.

*Yes, it's pretty dumb that I generate these separately & save these as separate files. I was younger and dumber when I wrote this code. Alas, I don't have time to go back and take on the refactoring to make this simpler.